### PR TITLE
Remove 'phone' from pathmap.

### DIFF
--- a/core/pathmap.mk
+++ b/core/pathmap.mk
@@ -116,7 +116,6 @@ FRAMEWORKS_BASE_SUBDIRS := \
 	    sax \
 	    telecomm \
 	    telephony \
-	    phone \
 	    wifi \
 	    keystore \
 	    rs \


### PR DESCRIPTION
This commit remove the "annoying" sentence
find: "phone": No such file or directory

Change-Id: I9227f8ff3a63da6b13011ecebc9640c106ae3542