### PR TITLE
Squashed commit for chromium_prebuilt (2/3)

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1670,11 +1670,16 @@ $(INTERNAL_OTA_PACKAGE_TARGET): $(BUILT_TARGET_FILES_PACKAGE) $(DISTTOOLS)
 
 .PHONY: otapackage bacon bootzip
 otapackage: $(INTERNAL_OTA_PACKAGE_TARGET)
-
 bacon: check_bacon otapackage
 ifneq ($(DU_BUILD),)
 	$(hide) ln -f $(INTERNAL_OTA_PACKAGE_TARGET) $(DU_TARGET_PACKAGE)
 	$(hide) $(MD5SUM) $(DU_TARGET_PACKAGE) > $(DU_TARGET_PACKAGE).md5sum
+ifeq ($(USE_PREBUILT_CHROMIUM),true)
+ifneq ($(PRODUCT_PREBUILT_WEBVIEWCHROMIUM),yes)
+	@echo "Running Chromium prebuilt setup script..."
+	$(hide) . $(TOPDIR)vendor/du/utils/chromium_prebuilt.sh $(TOP)
+endif
+endif
 	@echo -e ${CL_RED}""${CL_RED}
 	@echo -e ${CL_RED}".......................########..####.########..########.##....##......................"${CL_RED}
 	@echo -e ${CL_RED}".......................##.....##..##..##.....##....##.....##..##......................."${CL_RED}

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -635,11 +635,9 @@ function lunch()
 
     echo
 
-    if [[ $USE_PREBUILT_CHROMIUM -eq 1 ]]; then
+    if $USE_PREBUILT_CHROMIUM
+    then
         chromium_prebuilt
-    else
-        # Unset flag in case user opts out later on
-        export PRODUCT_PREBUILT_WEBVIEWCHROMIUM=""
     fi
 
     set_stuff_for_environment
@@ -1994,6 +1992,21 @@ function pez {
     return $retval
 }
 
+function chromium_prebuilt() {
+    T=$(gettop)
+    export TARGET_DEVICE=$(get_build_var TARGET_DEVICE)
+    hash=$T/prebuilts/chromium/$TARGET_DEVICE/hash.txt
+
+    if [ -r $hash ] && [ $(git --git-dir=$T/external/chromium_org/.git --work-tree=$T/external/chromium_org rev-parse --verify HEAD) == $(cat $hash) ]
+    then
+        export PRODUCT_PREBUILT_WEBVIEWCHROMIUM=yes
+        echo "** Prebuilt Chromium is up-to-date; Will be used for build **"
+    else
+        export PRODUCT_PREBUILT_WEBVIEWCHROMIUM=no
+        echo "** Prebuilt Chromium out-of-date/not found; Will build from source **"
+    fi
+}
+
 function get_make_command()
 {
   echo command make
@@ -2024,20 +2037,6 @@ function make()
     fi
     echo
     return $ret
-}
-
-function chromium_prebuilt() {
-    T=$(gettop)
-    export TARGET_DEVICE=$(get_build_var TARGET_DEVICE)
-    hash=$T/prebuilts/chromium/$TARGET_DEVICE/hash.txt
-
-    if [ -r $hash ] && [ $(git --git-dir=$T/external/chromium_org/.git --work-tree=$T/external/chromium_org rev-parse --verify HEAD) == $(cat $hash) ]; then
-        export PRODUCT_PREBUILT_WEBVIEWCHROMIUM=yes
-        echo "** Prebuilt Chromium is up-to-date; Will be used for build **"
-    else
-        export PRODUCT_PREBUILT_WEBVIEWCHROMIUM=no
-        echo "** Prebuilt Chromium out-of-date/not found; Will build from source **"
-    fi
 }
 
 if [ "x$SHELL" != "x/bin/bash" ]; then


### PR DESCRIPTION
build: Add chromium prebuilt support to envsetup.sh && The core Makefile

This adds a chromium_prebuilt function to envsetup.sh that is invoked by lunch to check
whether the chromium prebuilts are up-to-date or not. If not, it will be built from source
and then the new source built version will be pulled during brunch/mka bacon to become the
new prebuilts for future builds.

This is all opt-in through the USE_PREBUILT_CHROMIUM flag. Without it being set to 1,
none of this would be ran, and regular operations will go on.

PS13:
-use export TARGET_DEVICE
-replace git -C with params compatible to old git versions

Change-Id: I40f8c8dbd2a8a84a5c1b9f47ee04180a71ef4e07

build: Fix PreBuilt Chromium refs

Change-Id: Icc553d5be1e71d8c754bc85b6906252e5690b508