### PR TITLE
build sign_target_files_apks.py: clean tmp on exit

### DIFF
--- a/tools/releasetools/sign_target_files_apks.py
+++ b/tools/releasetools/sign_target_files_apks.py
@@ -747,3 +747,5 @@ if __name__ == '__main__':
     print("   ERROR: %s" % e)
     print()
     sys.exit(1)
+  finally:
+    common.Cleanup()


### PR DESCRIPTION
Currently, this script creates and leaves nearly 2GB in tmp
per run.  Clean up on exit.

Change-Id: I4247dd2508e9d27de57c611c18e70800d7a47f33